### PR TITLE
Fix for incorrect NSP on SFs.

### DIFF
--- a/demo-asymmetric-chain/sf-config.sh
+++ b/demo-asymmetric-chain/sf-config.sh
@@ -15,8 +15,3 @@ fi
 
 sudo ovs-vsctl add-br $sw
 sudo ovs-vsctl add-port $sw $sw-vxlangpe-0 -- set interface $sw-vxlangpe-0 type=vxlan options:remote_ip=flow options:dst_port=6633 options:nshc1=flow options:nshc2=flow options:nshc3=flow options:nshc4=flow options:nsp=flow options:nsi=flow options:key=flow
-for i in `seq 1 5`; do
-    sudo ovs-ofctl add-flow $sw "priority=1000,nsp=$i,nsi=255 actions=move:NXM_NX_NSH_C1[]->NXM_NX_NSH_C1[],move:NXM_NX_NSH_C2[]->NXM_NX_NSH_C2[],move:NXM_NX_TUN_ID[0..31]->NXM_NX_TUN_ID[0..31],load:$TUNNEL->NXM_NX_TUN_IPV4_DST[],set_nsi:254,set_nsp:0x$i,IN_PORT" -OOpenFlow13
-    sudo ovs-ofctl add-flow $sw "priority=1000,nsp=$i,nsi=254 actions=move:NXM_NX_NSH_C1[]->NXM_NX_NSH_C1[],move:NXM_NX_NSH_C2[]->NXM_NX_NSH_C2[],move:NXM_NX_TUN_ID[0..31]->NXM_NX_TUN_ID[0..31],load:$TUNNEL->NXM_NX_TUN_IPV4_DST[],set_nsi:253,set_nsp:0x$i,IN_PORT" -OOpenFlow13
-done;
-

--- a/demo-symmetric-chain/sf-config.sh
+++ b/demo-symmetric-chain/sf-config.sh
@@ -15,8 +15,3 @@ fi
 
 sudo ovs-vsctl add-br $sw
 sudo ovs-vsctl add-port $sw $sw-vxlangpe-0 -- set interface $sw-vxlangpe-0 type=vxlan options:remote_ip=flow options:dst_port=6633 options:nshc1=flow options:nshc2=flow options:nshc3=flow options:nshc4=flow options:nsp=flow options:nsi=flow options:key=flow
-for i in `seq 1 5`; do
-    sudo ovs-ofctl add-flow $sw "priority=1000,nsp=$i,nsi=255 actions=move:NXM_NX_NSH_C1[]->NXM_NX_NSH_C1[],move:NXM_NX_NSH_C2[]->NXM_NX_NSH_C2[],move:NXM_NX_TUN_ID[0..31]->NXM_NX_TUN_ID[0..31],load:$TUNNEL->NXM_NX_TUN_IPV4_DST[],set_nsi:254,set_nsp:0x$i,IN_PORT" -OOpenFlow13
-    sudo ovs-ofctl add-flow $sw "priority=1000,nsp=$i,nsi=254 actions=move:NXM_NX_NSH_C1[]->NXM_NX_NSH_C1[],move:NXM_NX_NSH_C2[]->NXM_NX_NSH_C2[],move:NXM_NX_TUN_ID[0..31]->NXM_NX_TUN_ID[0..31],load:$TUNNEL->NXM_NX_TUN_IPV4_DST[],set_nsi:253,set_nsp:0x$i,IN_PORT" -OOpenFlow13
-done;
-

--- a/get-nsps.py
+++ b/get-nsps.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+import socket
+import requests,json
+from requests.auth import HTTPBasicAuth
+import sys
+import os
+from subprocess import check_output
+from infrastructure_config import *
+
+
+DEFAULT_PORT='8181'
+USERNAME='admin'
+PASSWORD='admin'
+
+def get(host, port, uri):
+    url='http://'+host+":"+port+uri
+    #print url
+    r = requests.get(url, auth=HTTPBasicAuth(USERNAME, PASSWORD))
+    jsondata=json.loads(r.text)
+    return jsondata
+
+
+def get_rsps_uri():
+	return "/restconf/operational/rendered-service-path:rendered-service-paths"
+
+def doCmd(cmd):
+    listcmd=cmd.split()
+    print check_output(listcmd)
+
+if __name__ == "__main__":
+    # Launch main menu
+
+
+    # Some sensible defaults
+    controller=os.environ.get('ODL')
+    if controller == None:
+        sys.exit("No controller set.")
+    #else:
+	#print "Contacting controller at %s" % controller
+
+    resp=get(controller,DEFAULT_PORT,get_rsps_uri())
+    if len(resp['rendered-service-paths']) > 0:
+       paths=resp['rendered-service-paths']['rendered-service-path']
+
+       nsps=[]
+       for path in paths:
+           nsps.append(path['path-id'])
+       if len(nsps) > 0:
+           sw_index=int(socket.gethostname().split("gbpsfc",1)[1])-1
+           if sw_index in range(0,len(switches)+1):
+
+              controller=os.environ.get('ODL')
+              sw_type = switches[sw_index]['type']
+              sw_name = switches[sw_index]['name']
+              if sw_type == 'sf':
+                  print "******************************"
+                  print "Adding flows for %s as an SF." % sw_name
+                  print "******************************"
+                  doCmd('sudo /vagrant/utils/sf-flows.sh %s' % min(nsps))
+

--- a/startdemo.sh
+++ b/startdemo.sh
@@ -32,5 +32,11 @@ done
 echo "Configuring controller..."
 ./$demo/rest.py
 
+echo "Post-controller configuration..."
+for i in `seq 1 $NUM_NODES`; do
+  hostname="gbpsfc"$i
+  echo $hostname
+  vagrant ssh $hostname -c "sudo -E /vagrant/get-nsps.py"
+done
 echo "$demo" > demo.lock
 

--- a/utils/sf-flows.sh
+++ b/utils/sf-flows.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+hostnum=${HOSTNAME#"gbpsfc"}
+sw="sw$hostnum"
+nsp=$1
+
+if [ "$hostnum" -eq "3" ]; then
+    TUNNEL=0xC0A83247
+elif [ "$hostnum" -eq "5" ]; then
+    TUNNEL=0xC0A83249
+else
+    echo "Invalid SF for this demo";
+    exit
+fi
+# delete NORMAL, if present
+nsphex=`printf "%x\n" $nsp`
+sudo ovs-ofctl --strict del-flows $sw priority=0
+sudo ovs-ofctl add-flow $sw "priority=1000,nsp=$nsp,nsi=255 actions=move:NXM_NX_NSH_C1[]->NXM_NX_NSH_C1[],move:NXM_NX_NSH_C2[]->NXM_NX_NSH_C2[],move:NXM_NX_TUN_ID[0..31]->NXM_NX_TUN_ID[0..31],load:$TUNNEL->NXM_NX_TUN_IPV4_DST[],set_nsi:254,set_nsp:0x$nsphex,IN_PORT" -OOpenFlow13
+sudo ovs-ofctl add-flow $sw "priority=1000,nsp=$nsp,nsi=254 actions=move:NXM_NX_NSH_C1[]->NXM_NX_NSH_C1[],move:NXM_NX_NSH_C2[]->NXM_NX_NSH_C2[],move:NXM_NX_TUN_ID[0..31]->NXM_NX_TUN_ID[0..31],load:$TUNNEL->NXM_NX_TUN_IPV4_DST[],set_nsi:253,set_nsp:0x$nsphex,IN_PORT" -OOpenFlow13
+
+let "nsp += 1"
+nsphex=`printf "%x\n" $nsp`
+sudo ovs-ofctl add-flow $sw "priority=1000,nsp=$nsp,nsi=255 actions=move:NXM_NX_NSH_C1[]->NXM_NX_NSH_C1[],move:NXM_NX_NSH_C2[]->NXM_NX_NSH_C2[],move:NXM_NX_TUN_ID[0..31]->NXM_NX_TUN_ID[0..31],load:$TUNNEL->NXM_NX_TUN_IPV4_DST[],set_nsi:254,set_nsp:0x$nsphex,IN_PORT" -OOpenFlow13
+sudo ovs-ofctl add-flow $sw "priority=1000,nsp=$nsp,nsi=254 actions=move:NXM_NX_NSH_C1[]->NXM_NX_NSH_C1[],move:NXM_NX_NSH_C2[]->NXM_NX_NSH_C2[],move:NXM_NX_TUN_ID[0..31]->NXM_NX_TUN_ID[0..31],load:$TUNNEL->NXM_NX_TUN_IPV4_DST[],set_nsi:253,set_nsp:0x$nsphex,IN_PORT" -OOpenFlow13
+
+#sudo ovs-ofctl add-flow $sw "priority=1000,nsp=$nsp,nsi=255 actions=move:NXM_NX_NSH_C1[]->NXM_NX_NSH_C1[],move:NXM_NX_NSH_C2[]->NXM_NX_NSH_C2[],move:NXM_NX_TUN_ID[0..31]->NXM_NX_TUN_ID[0..31],load:0xC0A83247->NXM_NX_TUN_IPV4_DST[],set_nsi:254,set_nsp:$nsp,IN_PORT" -OOpenFlow13
+#sudo ovs-ofctl add-flow $sw "priority=1000,nsp=$nsp,nsi=254 actions=move:NXM_NX_NSH_C1[]->NXM_NX_NSH_C1[],move:NXM_NX_NSH_C2[]->NXM_NX_NSH_C2[],move:NXM_NX_TUN_ID[0..31]->NXM_NX_TUN_ID[0..31],load:0xC0A83249->NXM_NX_TUN_IPV4_DST[],set_nsi:253,set_nsp:$nsp,IN_PORT" -OOpenFlow13
+
+#let "nsp += 1"
+#sudo ovs-ofctl add-flow $sw "priority=1000,nsp=$nsp,nsi=255 actions=move:NXM_NX_NSH_C1[]->NXM_NX_NSH_C1[],move:NXM_NX_NSH_C2[]->NXM_NX_NSH_C2[],move:NXM_NX_TUN_ID[0..31]->NXM_NX_TUN_ID[0..31],load:0xC0A83249->NXM_NX_TUN_IPV4_DST[],set_nsi:254,set_nsp:$nsp,IN_PORT" -OOpenFlow13
+#sudo ovs-ofctl add-flow $sw "priority=1000,nsp=$nsp,nsi=254 actions=move:NXM_NX_NSH_C1[]->NXM_NX_NSH_C1[],move:NXM_NX_NSH_C2[]->NXM_NX_NSH_C2[],move:NXM_NX_TUN_ID[0..31]->NXM_NX_TUN_ID[0..31],load:0xC0A83247->NXM_NX_TUN_IPV4_DST[],set_nsi:253,set_nsp:$nsp,IN_PORT" -OOpenFlow13


### PR DESCRIPTION
The SFs were hard-coded with the NSP. This patch adds
reads of the NSP from the SFC data store, and uses it
to create the flows on the SFs.

Signed-off-by: Thomas Bachman tbachman@yahoo.com
